### PR TITLE
Support relative urls when downloading charts

### DIFF
--- a/helm-adopt-package-history.sh
+++ b/helm-adopt-package-history.sh
@@ -212,6 +212,9 @@ download_package_history() {
             local v=$(basename $f .tgz | cut -d'-' -f2)
             tput cuu 1 && tput el
             echo "$cm. package $v ($pi of $pn)"
+            if [[ $url != *"://"* ]]; then
+                url="${old_repo_url}/${url}"
+            fi
             curl -SsLo $download_dir/$f $url
         done
         tput cuu 1 && tput el


### PR DESCRIPTION
I am checking for `://` to identify if a protocol (http, https, file, ...) is configured. In case it's not I simply prepend the repo url.